### PR TITLE
Remove unused blockableBy fields

### DIFF
--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -273,7 +273,6 @@ Constants.SpellMetadata = {
     VISUAL_SHAPE = "visualShape",
     VFX = "vfx",
     SFX = "sfx",
-    BLOCKABLE_BY = "blockableBy",
     ZONE = "zone"
 }
 

--- a/docs/keywords.lua
+++ b/docs/keywords.lua
@@ -134,7 +134,6 @@ function DocGenerator.generateMarkdown()
     output = output .. "        }\n"
     output = output .. "    },\n"
     output = output .. "    vfx = \"arcane_reversal\",\n"
-    output = output .. "    blockableBy = {\"ward\", \"field\"}\n"
     output = output .. "}\n```\n\n"
     
     -- Fireball example
@@ -162,7 +161,6 @@ function DocGenerator.generateMarkdown()
     output = output .. "    },\n"
     output = output .. "    vfx = \"fireball\",\n"
     output = output .. "    sfx = \"explosion\",\n"
-    output = output .. "    blockableBy = {\"barrier\"}\n"
     output = output .. "}\n```\n\n"
     
     return output

--- a/docs/spellcasting.md
+++ b/docs/spellcasting.md
@@ -28,7 +28,7 @@ This system is transitioning towards a pure event-based architecture, where spel
     *   **Basic Info:** `id`, `name`, `description`.
     *   **Mechanics:** `attackType` (`projectile`, `remote`, `zone`, `utility`), `castTime`, `cost` (array of token types like `Constants.TokenType.FIRE`).
     *   **`keywords`:** **The core.** A table mapping keyword names (from `keywords.lua`) to parameter tables (e.g., `damage = { amount = 10 }`, `elevate = { duration = 5.0 }`). Parameters can be static values or functions.
-    *   **Optional:** `vfx`, `sfx`, `blockableBy` (array of shield types), `getCastTime` (dynamic cast time function), `onBlock`/`onMiss`/`onSuccess` (legacy callbacks).
+*   **Optional:** `vfx`, `sfx`, `getCastTime` (dynamic cast time function), `onBlock`/`onMiss`/`onSuccess` (legacy callbacks).
 *   **Validation:** Includes a `validateSpell` function called at load time to ensure schema adherence and add defaults, printing warnings for issues.
 
 ### 3. `spellCompiler.lua` - The Chef

--- a/main.lua
+++ b/main.lua
@@ -253,7 +253,6 @@ function love.load()
         },
         vfx = "moon_ward",
         sfx = "shield_up",
-        blockableBy = {}
     }
     
     -- Define Mirror Shield with minimal dependencies
@@ -275,7 +274,6 @@ function love.load()
         },
         vfx = "mirror_shield",
         sfx = "crystal_ring",
-        blockableBy = {}
     }
     
     -- Compile custom spells too

--- a/spellCompiler.lua
+++ b/spellCompiler.lua
@@ -60,7 +60,6 @@ function SpellCompiler.compileSpell(spellDef, keywordData)
         visualShape = spellDef.visualShape, -- Copy visualShape for template override
         vfx = spellDef.vfx,
         sfx = spellDef.sfx,
-        blockableBy = spellDef.blockableBy,
         -- Create empty behavior table to store merged behavior data
         behavior = {}
     }

--- a/spells/README.md
+++ b/spells/README.md
@@ -50,6 +50,5 @@ Each spell must follow this schema:
 - `castTime`: Duration in seconds (number)
 - `cost`: Array of token types required (array)
 - `keywords`: Table of effect keywords and parameters (table)
-- `blockableBy`: Array of shield types that can block this spell (array, optional)
 
 See `schema.lua` for detailed validation logic.

--- a/spells/elements/fire.lua
+++ b/spells/elements/fire.lua
@@ -22,7 +22,6 @@ FireSpells.conjurefire = {
             amount = 1
         },
     },
-    blockableBy = {},
     
     -- Custom cast time calculation based on existing fire tokens
     getCastTime = function(caster)
@@ -66,7 +65,6 @@ FireSpells.firebolt = {
         },
     },
     sfx = "fire_whoosh",
-    blockableBy = {Constants.ShieldType.BARRIER, Constants.ShieldType.WARD}
 }
 
 -- Fireball spell
@@ -87,7 +85,6 @@ FireSpells.fireball = {
                 duration = 2
             }
         },
-        blockableBy = {Constants.ShieldType.BARRIER, Constants.ShieldType.WARD}
     }
 }
 
@@ -163,7 +160,6 @@ FireSpells.blazingAscent = {
         },
     },
     sfx = "fire_whoosh",
-    blockableBy = {Constants.ShieldType.BARRIER}
 }
 
 -- Eruption spell
@@ -193,7 +189,6 @@ FireSpells.eruption = {
         },
     },
     sfx = "volcano_rumble",
-    blockableBy = {Constants.ShieldType.BARRIER},
     
     onMiss = function(caster, target, slot)
         print(string.format("[MISS] %s's Lava Eruption misses because conditions aren't right!", caster.name))
@@ -260,7 +255,6 @@ FireSpells.battleshield = {
         },
     },
     sfx = "fire_shield",
-    blockableBy = {}
 }
 
 return FireSpells

--- a/spells/elements/moon.lua
+++ b/spells/elements/moon.lua
@@ -22,7 +22,6 @@ MoonSpells.conjuremoonlight = {
             amount = 1
         },
     },
-    blockableBy = {},
     
     getCastTime = function(caster)
         local baseCastTime = Constants.CastSpeed.FAST
@@ -61,7 +60,6 @@ MoonSpells.tidalforce = {
         },
     },
     sfx = "tidal_wave",
-    blockableBy = {Constants.ShieldType.WARD}
 }
 
 -- Lunar Disjunction spell
@@ -88,7 +86,6 @@ MoonSpells.lunardisjunction = {
         },
     },
     sfx = "lunardisjunction_sound",
-    blockableBy = {Constants.ShieldType.WARD}
 }
 
 -- Moon Dance spell
@@ -153,7 +150,6 @@ MoonSpells.gravity = {
         },
     },
     sfx = "gravity_slam",
-    blockableBy = {Constants.ShieldType.WARD}
 }
 
 -- Eclipse spell
@@ -178,7 +174,6 @@ MoonSpells.eclipse = {
         },
     },
     sfx = "eclipse_shatter",
-    blockableBy = {}
 }
 
 -- Full Moon Beam spell
@@ -221,7 +216,6 @@ MoonSpells.fullmoonbeam = {
         }
     },
     sfx = "beam_charge",
-    blockableBy = {Constants.ShieldType.BARRIER, Constants.ShieldType.WARD}
 }
 
 -- Lunar Tides spell
@@ -254,7 +248,6 @@ MoonSpells.lunarTides = {
         },
     },
     sfx = "tide_rush",
-    blockableBy = {Constants.ShieldType.WARD}
 }
 
 -- Wings of Moonlight (shield spell)
@@ -291,7 +284,6 @@ MoonSpells.wrapinmoonlight = {
         },
     },
     sfx = "mist_shimmer",
-    blockableBy = {},
 }
 
 -- Gravity Trap spell
@@ -333,7 +325,6 @@ MoonSpells.gravityTrap = {
         },
     },
     sfx = "gravity_trap_set",
-    blockableBy = {}
 }
 
 -- Infinite Procession spell
@@ -398,7 +389,6 @@ MoonSpells.enhancedmirrorshield = {
         },
     },
     sfx = "crystal_ring",
-    blockableBy = {}
 }
 
 return MoonSpells

--- a/spells/elements/salt.lua
+++ b/spells/elements/salt.lua
@@ -20,7 +20,6 @@ SaltSpells.conjuresalt = {
             amount = 1
         },
     },
-    blockableBy = {},
 
     getCastTime = function(caster)
         local baseCastTime = Constants.CastSpeed.FAST
@@ -56,7 +55,6 @@ SaltSpells.glitterfang = {
         },
     },
     sfx = "glitter_fang",
-    blockableBy = {}
 }
 
 -- Salt Storm spell
@@ -77,7 +75,6 @@ SaltSpells.saltstorm = {
         shieldBreaker = 2,
     },
     sfx = "salt_storm",
-    blockableBy = {Constants.ShieldType.BARRIER}
 }
 
 -- Imprison spell (Salt trap)
@@ -112,7 +109,6 @@ SaltSpells.imprison = {
         },
     },
     sfx = "gravity_trap_set",
-    blockableBy = {} 
 }
 
 -- Jagged Earth spell (Salt trap)
@@ -137,7 +133,6 @@ SaltSpells.jaggedearth = {
         },
     },
     sfx = "jagged_earth",
-    blockableBy = {Constants.ShieldType.BARRIER}
 }
 
 -- Salt Circle spell (Ward)
@@ -156,7 +151,6 @@ SaltSpells.saltcircle = {
         }
     },
     sfx = "salt_circle",
-    blockableBy = {}
 }
 
 -- Stone Shield spell (Barrier)
@@ -175,7 +169,6 @@ SaltSpells.stoneshield = {
         }
     },
     sfx = "stone_shield",
-    blockableBy = {}
 }
 
 -- Shield-breaking spell
@@ -209,7 +202,6 @@ SaltSpells.shieldbreaker = {
     },
     shieldBreaker = 3,
     sfx = "shield_break",
-    blockableBy = {Constants.ShieldType.BARRIER, Constants.ShieldType.WARD},
     
     onBlock = function(caster, target, slot, blockInfo)
         print(string.format("[SHIELD BREAKER] %s's Shield Breaker is testing the %s shield's strength!", 

--- a/spells/elements/star.lua
+++ b/spells/elements/star.lua
@@ -22,7 +22,6 @@ StarSpells.conjurestars = {
             amount = 1
         },
     },
-    blockableBy = {},
 
     getCastTime = function(caster)
         local baseCastTime = Constants.CastSpeed.FAST
@@ -76,7 +75,6 @@ StarSpells.adaptive_surge = {
         ),
     },
     sfx = "adaptive_sound",
-    blockableBy = {Constants.ShieldType.BARRIER, Constants.ShieldType.WARD}
 }
 
 -- Cosmic Rift spell
@@ -101,7 +99,6 @@ StarSpells.cosmicRift = {
         zoneMulti = true,
     },
     sfx = "space_tear",
-    blockableBy = {Constants.ShieldType.BARRIER}
 }
 
 return StarSpells

--- a/spells/elements/sun.lua
+++ b/spells/elements/sun.lua
@@ -28,7 +28,6 @@ SunSpells.radiantbolt = {
         },
     },
     sfx = "fire_whoosh",
-    blockableBy = {Constants.ShieldType.BARRIER, Constants.ShieldType.WARD}
 }
 
 -- Meteor spell
@@ -59,7 +58,6 @@ SunSpells.meteor = {
         }
     },
     sfx = "meteor_impact",
-    blockableBy = {Constants.ShieldType.BARRIER, Constants.ShieldType.FIELD}
 }
 
 -- Emberlift spell
@@ -90,7 +88,6 @@ SunSpells.emberlift = {
         }
     },
     sfx = "whoosh_up",
-    blockableBy = {}
 }
 
 -- Nova Conjuring (Combine 3 x FIRE into SUN)
@@ -113,7 +110,6 @@ SunSpells.novaconjuring = {
         },
     },
     sfx = "conjure_nova",
-    blockableBy = {}
 }
 
 -- Force Barrier spell (Sun-based shield)
@@ -133,7 +129,6 @@ SunSpells.forcebarrier = {
         },
     },
     sfx = "shield_up",
-    blockableBy = {}
 }
 
 return SunSpells

--- a/spells/elements/void.lua
+++ b/spells/elements/void.lua
@@ -53,7 +53,6 @@ VoidSpells.heartripper = {
         }
     },
     sfx = "heartripper",
-    blockableBy = {Constants.ShieldType.WARD}
 }
 
 return VoidSpells

--- a/spells/elements/water.lua
+++ b/spells/elements/water.lua
@@ -27,7 +27,6 @@ WaterSpells.watergun = {
         }
     },
     sfx = "fire_whoosh",
-    blockableBy = {Constants.ShieldType.BARRIER, Constants.ShieldType.WARD}
 }
 
 -- Force blast spell (Steam Vent) - water and fire combo
@@ -50,7 +49,6 @@ WaterSpells.forceBlast = {
         },
     },
     sfx = "force_wind",
-    blockableBy = {Constants.ShieldType.BARRIER}
 }
 
 return WaterSpells

--- a/spells/schema.lua
+++ b/spells/schema.lua
@@ -24,7 +24,6 @@ local Schema = {}
 -- visualShape: Visual shape identifier to override default template based on attackType (string, optional)
 -- vfx: Visual effect identifier (string, optional)
 -- sfx: Sound effect identifier (string, optional)
--- blockableBy: Array of shield types that can block this spell (array, optional)
 --
 -- Shield Types and Blocking Rules:
 -- * barrier: Physical shield that blocks projectiles and zones
@@ -117,15 +116,8 @@ function Schema.validateSpell(spell, spellId)
         spell.keywords = {}
     end
     
-    -- Check blockableBy (if present)
-    if spell.blockableBy then
-        if type(spell.blockableBy) ~= "table" then
-            print("WARNING: Spell " .. spellId .. " blockableBy must be a table, fixing")
-            spell.blockableBy = {}
         end
     else
-        -- Create empty blockableBy table
-        spell.blockableBy = {}
     end
     
     return true

--- a/tools/check_magic_strings.lua
+++ b/tools/check_magic_strings.lua
@@ -90,8 +90,7 @@ local function scanFile(filepath)
                         -- Ignore if it's in a comment at end of line
                         if not line:match("%-%-.*" .. pattern) then
                             -- Ignore if it appears to be in a block definition context (for legacy compatibility)
-                            if not line:match("blockableBy%s*=%s*{.*" .. pattern .. ".*}") and
-                               not line:match("supportedTypes%s*=%s*{.*" .. pattern .. ".*}") and
+                            if not line:match("supportedTypes%s*=%s*{.*" .. pattern .. ".*}") and
                                not line:match("cost%s*=%s*{.*" .. pattern .. ".*}") and
                                not line:match("return%s+.*" .. pattern) then
                                 table.insert(issues, {


### PR DESCRIPTION
## Summary
- drop `blockableBy` from spell definitions
- stop validating `blockableBy` in the schema and remove constant
- update docs and examples to reflect removal
- adjust magic string checker accordingly

## Testing
- `grep -R "blockableBy" -n | grep -v manastorm_codebase_dump`