### PR TITLE
Remove duplicate getAllSpellMetadataFields

### DIFF
--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -259,15 +259,6 @@ function Constants.getAllAttackTypes()
         Constants.AttackType.UTILITY
     }
 end
--- Utility function to get all spell metadata fields
-function Constants.getAllSpellMetadataFields()
-    local fields = {}
-    for _, value in pairs(Constants.SpellMetadata) do
-        table.insert(fields, value)
-    end
-    return fields
-end
-
 -- Spell metadata field names for consistent reference
 Constants.SpellMetadata = {
     ID = "id",


### PR DESCRIPTION
## Summary
- remove the redundant `getAllSpellMetadataFields` function definition from `core/Constants.lua`

## Testing
- `git show --stat`