### PR TITLE
Remove trap window handling

### DIFF
--- a/keywords.lua
+++ b/keywords.lua
@@ -119,32 +119,6 @@ Keywords.trap_trigger = {
     end
 }
 
--- trap_window: Defines the duration or condition for a trap spell's expiration
-Keywords.trap_window = {
-    -- Behavior definition
-    behavior = {
-        storesWindowCondition = true,
-        category = "TRAP"
-    },
-    
-    -- Implementation function - Stores window condition/duration
-    execute = function(params, caster, target, results, events)
-        results.trapWindow = params
-        
-        -- Log info based on whether it's duration or condition-based
-        if params.duration then
-            print(string.format("[TRAP] Stored window duration: %.1f seconds", 
-                params.duration))
-        elseif params.condition then
-            print(string.format("[TRAP] Stored window condition: %s", 
-                params.condition))
-        else
-            print("[TRAP] Warning: Window with no duration or condition")
-        end
-        
-        return results
-    end
-}
 
 -- trap_effect: Defines the effect that occurs when a trap is triggered
 Keywords.trap_effect = {

--- a/spellCompiler.lua
+++ b/spellCompiler.lua
@@ -307,18 +307,6 @@ function SpellCompiler.compileSpell(spellDef, keywordData)
             end
         end
         
-        if compiledSpell.behavior.trap_window then
-            -- Make sure trapWindow data is in the results
-            if not results.trapWindow then
-                results.trapWindow = compiledSpell.behavior.trap_window.params or {}
-                print("DEBUG: Adding trapWindow data to results: " .. tostring(results.trapWindow))
-                
-                -- Debug what's in the params
-                for k, v in pairs(compiledSpell.behavior.trap_window.params or {}) do
-                    print("DEBUG:   trapWindow param: " .. k .. " = " .. tostring(v))
-                end
-            end
-        end
         
         if compiledSpell.behavior.trap_effect then
             -- Make sure trapEffect data is in the results

--- a/spells/elements/moon.lua
+++ b/spells/elements/moon.lua
@@ -303,9 +303,6 @@ MoonSpells.gravityTrap = {
             condition = "on_opponent_elevate" 
         },
         
-        trap_window = { 
-            duration = 600.0
-        },
         
         trap_effect = {
             damage = { 

--- a/spells/elements/salt.lua
+++ b/spells/elements/salt.lua
@@ -93,9 +93,6 @@ SaltSpells.imprison = {
             condition = "on_opponent_far" 
         },
         
-        trap_window = { 
-            duration = 600.0
-        },
         
         trap_effect = {
             damage = { 

--- a/systems/SustainedSpellManager.lua
+++ b/systems/SustainedSpellManager.lua
@@ -10,10 +10,8 @@ local SustainedSpellManager = {}
 --   wizard = reference to wizard who cast the spell,
 --   slotIndex = index of the spell slot,
 --   spell = reference to the spell,
---   windowData = expiry conditions (duration or state),
 --   triggerData = trigger conditions (for traps),
 --   effectData = effect to apply when triggered (for traps),
---   expiryTimer = countdown for duration-based expiry,
 --   type = "shield" or "trap" or "generic"
 -- }
 SustainedSpellManager.activeSpells = {}
@@ -33,7 +31,6 @@ function SustainedSpellManager.addSustainedSpell(wizard, slotIndex, spellData)
     print("[DEBUG] SustainedSpellManager.addSustainedSpell: Spell data:")
     print("[DEBUG]   isSustained: " .. tostring(spellData.isSustained))
     print("[DEBUG]   trapTrigger exists: " .. tostring(spellData.trapTrigger ~= nil))
-    print("[DEBUG]   trapWindow exists: " .. tostring(spellData.trapWindow ~= nil))
     print("[DEBUG]   trapEffect exists: " .. tostring(spellData.trapEffect ~= nil))
     
     -- Generate a unique ID for this sustained spell
@@ -61,12 +58,6 @@ function SustainedSpellManager.addSustainedSpell(wizard, slotIndex, spellData)
     if spellType == "trap" then
         entry.triggerData = spellData.trapTrigger or {}
         entry.effectData = spellData.trapEffect or {}
-        entry.windowData = spellData.trapWindow or {}
-        
-        -- Initialize expiry timer if a duration is specified
-        if entry.windowData.duration and type(entry.windowData.duration) == "number" then
-            entry.expiryTimer = entry.windowData.duration
-        end
     end
     
     -- Add shield-specific data if present
@@ -129,50 +120,6 @@ function SustainedSpellManager.update(dt)
             genericCount = genericCount + 1
         end
         
-        -- Check for expiry conditions (BEFORE trigger checks)
-        if entry.windowData then
-            -- Duration-based expiry (already implemented)
-            if entry.windowData.duration and entry.expiryTimer and not entry.expired then
-                entry.expiryTimer = entry.expiryTimer - dt
-                
-                -- Check if the duration has expired
-                if entry.expiryTimer <= 0 then
-                    entry.expired = true
-                    print(string.format("[SustainedManager] Spell expired (duration) for %s slot %d", 
-                        entry.wizard.name, entry.slotIndex))
-                    table.insert(spellsToRemove, id)
-                end
-            end
-            
-            -- Condition-based expiry
-            if entry.windowData.condition and not entry.expired then
-                local condition = entry.windowData.condition
-                local conditionMet = false
-                
-                -- Check until_next_conjure condition
-                if condition == "until_next_conjure" and entry.wizard.justConjuredMana then
-                    conditionMet = true
-                    print(string.format("[SustainedManager] Spell expired (conjure condition) for %s slot %d", 
-                        entry.wizard.name, entry.slotIndex))
-                end
-                
-                -- Check while_elevated condition
-                if condition == "while_elevated" and entry.wizard.elevation ~= Constants.ElevationState.AERIAL then
-                    conditionMet = true
-                    print(string.format("[SustainedManager] Spell expired (elevation condition) for %s slot %d", 
-                        entry.wizard.name, entry.slotIndex))
-                end
-                
-                -- Check other conditions as needed
-                -- Add new condition checks here as the system expands
-                
-                -- If any condition is met, mark for expiry
-                if conditionMet then
-                    entry.expired = true
-                    table.insert(spellsToRemove, id)
-                end
-            end
-        end
         
         -- Process trap trigger conditions if this is a trap
         if entry.type == "trap" and entry.triggerData and not entry.triggered then
@@ -338,43 +285,15 @@ function SustainedSpellManager.update(dt)
                 table.insert(spellsToRemove, id)
             end
         end
-        
-        -- Duration-based expiry now handled at the top of the loop
-        
+
         ::continue::
     end
     
-    -- Remove expired and triggered spells after iteration
+    -- Remove triggered spells after iteration
     for _, id in ipairs(spellsToRemove) do
         local entry = SustainedSpellManager.activeSpells[id]
         if entry then
-            -- Expire spells without triggering trap effects
-            if entry.expired and not entry.triggered and not entry.processed then
-                print(string.format("[SustainedManager] Cleaning up expired spell for %s slot %d", 
-                    entry.wizard.name, entry.slotIndex))
-                
-                -- Clean up expired spell
-                local TokenManager = require("systems.TokenManager")
-                
-                -- Get the spell slot
-                local slot = entry.wizard.spellSlots[entry.slotIndex]
-                if slot then
-                    -- Return tokens to the mana pool
-                    if #slot.tokens > 0 then
-                        TokenManager.returnTokensToPool(slot.tokens)
-                        print(string.format("[SustainedManager] Returning %d tokens from expired spell", 
-                            #slot.tokens))
-                    end
-                    
-                    -- Reset the spell slot
-                    entry.wizard:resetSpellSlot(entry.slotIndex)
-                end
-                
-                -- Mark as processed to prevent duplicate processing
-                entry.processed = true
-            end
-            
-            -- Remove the spell from the manager, whether it was triggered or expired
+            -- Remove the spell from the manager
             SustainedSpellManager.removeSustainedSpell(id)
         end
     end

--- a/wizard.lua
+++ b/wizard.lua
@@ -1187,7 +1187,7 @@ function Wizard:castSpell(spellSlot)
                 local sustainedId = self.gameState.sustainedSpellManager.addSustainedSpell(
                     self,        -- wizard who cast the spell
                     spellSlot,   -- slot index where the spell is
-                    effect       -- effect table from executeAll (contains trapTrigger, trapWindow, trapEffect, etc.)
+                    effect       -- effect table from executeAll (contains trapTrigger, trapEffect, etc.)
                 )
                 
                 -- Store the sustained spell ID in the slot for reference


### PR DESCRIPTION
## Summary
- drop `trap_window` keyword and compiler support
- simplify sustained spell manager trap entries
- clean up trap comment in `wizard.lua`
- remove trap window data from example spells

## Testing
- `git diff --stat`
