### PR TITLE
Manage stun through statusEffects

### DIFF
--- a/docs/wizard.md
+++ b/docs/wizard.md
@@ -11,7 +11,8 @@ The `wizard.lua` module defines the "class" for the player characters in Manasto
 Each `Wizard` instance maintains a comprehensive set of state variables:
 
 *   **Identity & Position:** `name`, `x`, `y`, `color`.
-*   **Combat:** `health`, `stunTimer`.
+*   **Combat:** `health`.
+    *   Stun duration is tracked via `statusEffects[Constants.StatusType.STUN].duration`.
 *   **Positioning:**
     *   `elevation`: String ("GROUNDED" or "AERIAL").
     *   `elevationTimer`: Duration for temporary AERIAL state.

--- a/main.lua
+++ b/main.lua
@@ -378,7 +378,10 @@ function resetGame()
         wizard.health = 100
         wizard.elevation = Constants.ElevationState.GROUNDED
         wizard.elevationTimer = 0
-        wizard.stunTimer = 0
+        if wizard.statusEffects and wizard.statusEffects[Constants.StatusType.STUN] then
+            wizard.statusEffects[Constants.StatusType.STUN].active = false
+            wizard.statusEffects[Constants.StatusType.STUN].duration = 0
+        end
         
         -- Reset spell slots
         for i = 1, 3 do

--- a/systems/WizardVisuals.lua
+++ b/systems/WizardVisuals.lua
@@ -135,13 +135,14 @@ function WizardVisuals.drawStatusEffects(wizard)
     end
     
     -- Draw STUN duration if active
-    if wizard.stunTimer > 0 then
+    local stun = wizard.statusEffects and wizard.statusEffects[Constants.StatusType.STUN]
+    if stun and stun.duration > 0 then
         effectCount = effectCount + 1
         local y = baseY - (effectCount * (barHeight + barPadding))
-        
+
         -- Calculate progress (1.0 to 0.0 as time depletes)
         local maxDuration = 3.0  -- Assuming 3 seconds is max stun duration
-        local progress = wizard.stunTimer / maxDuration
+        local progress = stun.duration / maxDuration
         progress = math.min(1.0, progress)  -- Cap at 1.0
         
         -- Get color for stun state
@@ -829,10 +830,13 @@ function WizardVisuals.drawWizard(wizard)
         wizardColor = {2.0, 2.0, 2.0, 1} -- Super bright white
         
         -- Flash effect is now implemented with additive blending
-    elseif wizard.stunTimer > 0 then
-        -- Apply a yellow/white flash for stunned wizards
-        local flashIntensity = 0.5 + math.sin(love.timer.getTime() * 10) * 0.5
-        wizardColor = {1, 1, flashIntensity, 1}
+    else
+        local stun = wizard.statusEffects and wizard.statusEffects[Constants.StatusType.STUN]
+        if stun and stun.duration > 0 then
+            -- Apply a yellow/white flash for stunned wizards
+            local flashIntensity = 0.5 + math.sin(love.timer.getTime() * 10) * 0.5
+            wizardColor = {1, 1, flashIntensity, 1}
+        end
     end
     
     -- Set initial color for ground indicator

--- a/wizard.lua
+++ b/wizard.lua
@@ -60,7 +60,6 @@ function Wizard.new(name, x, y, color)
     self.health = 100
     self.elevation = Constants.ElevationState.GROUNDED  -- GROUNDED or AERIAL
     self.elevationTimer = 0      -- Timer for temporary elevation changes
-    self.stunTimer = 0           -- Stun timer in seconds
     
     -- Position animation state
     self.positionAnimation = {
@@ -82,6 +81,10 @@ function Wizard.new(name, x, y, color)
             tickInterval = 1.0,
             elapsed = 0,         -- Time since last tick
             totalTime = 0        -- Total time effect has been active
+        },
+        [Constants.StatusType.STUN] = {
+            active = false,
+            duration = 0
         }
     }
     
@@ -305,10 +308,12 @@ function Wizard:update(dt)
         end
     end
     
-    -- Update stun timer
-    if self.stunTimer > 0 then
-        self.stunTimer = math.max(0, self.stunTimer - dt)
-        if self.stunTimer == 0 then
+    -- Update stun status effect
+    local stun = self.statusEffects[Constants.StatusType.STUN]
+    if stun and stun.duration > 0 then
+        stun.duration = math.max(0, stun.duration - dt)
+        if stun.duration == 0 then
+            stun.active = false
             print(self.name .. " is no longer stunned")
         end
     end
@@ -527,8 +532,9 @@ end
 -- Handle key press and update currently keyed spell
 function Wizard:keySpell(keyIndex, isPressed)
     -- Check if wizard is stunned
-    if self.stunTimer > 0 and isPressed then
-        print(self.name .. " tried to key a spell but is stunned for " .. string.format("%.1f", self.stunTimer) .. " more seconds")
+    local stun = self.statusEffects[Constants.StatusType.STUN]
+    if stun and stun.duration > 0 and isPressed then
+        print(self.name .. " tried to key a spell but is stunned for " .. string.format("%.1f", stun.duration) .. " more seconds")
         return false
     end
     
@@ -568,8 +574,9 @@ end
 -- Cast the currently keyed spell
 function Wizard:castKeyedSpell()
     -- Check if wizard is stunned
-    if self.stunTimer > 0 then
-        print(self.name .. " tried to cast a spell but is stunned for " .. string.format("%.1f", self.stunTimer) .. " more seconds")
+    local stun = self.statusEffects[Constants.StatusType.STUN]
+    if stun and stun.duration > 0 then
+        print(self.name .. " tried to cast a spell but is stunned for " .. string.format("%.1f", stun.duration) .. " more seconds")
         return false
     end
     
@@ -607,8 +614,9 @@ end
 
 function Wizard:queueSpell(spell)
     -- Check if wizard is stunned
-    if self.stunTimer > 0 then
-        print(self.name .. " tried to queue a spell but is stunned for " .. string.format("%.1f", self.stunTimer) .. " more seconds")
+    local stun = self.statusEffects[Constants.StatusType.STUN]
+    if stun and stun.duration > 0 then
+        print(self.name .. " tried to queue a spell but is stunned for " .. string.format("%.1f", stun.duration) .. " more seconds")
         return false
     end
     


### PR DESCRIPTION
## Summary
- remove standalone `stunTimer`
- store stun duration inside `wizard.statusEffects`
- show stun effect using new field
- reset stun in `resetGame`
- update wizard documentation

## Testing
- `git status --short`