### PR TITLE
Add Silex unlock through Salt spells

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Manastorm is a real-time strategic battler where two spellcasters clash in arcan
 ### General
 - ESC: Quit the game
 
+## Unlocking Characters
+
+Casting any Salt-affinity spell during a match unlocks the wizard **Silex** for
+future character selection.
+
 ## Debug Logging
 
 Verbose debug output can be toggled at runtime. Require the `core.Log` module and

--- a/main.lua
+++ b/main.lua
@@ -113,7 +113,8 @@ game.characterRoster = {
 
 game.unlockedCharacters = {
     Ashgar = true,
-    Selene = true
+    Selene = true,
+    Silex = false
 }
 
 -- Get a list of all unlocked characters in the roster

--- a/systems/UnlockSystem.lua
+++ b/systems/UnlockSystem.lua
@@ -1,0 +1,30 @@
+-- systems/UnlockSystem.lua
+-- Simple character unlock logic
+
+local UnlockSystem = {}
+
+--- Check if a spell unlocks any characters
+-- Currently unlocks Silex when a Salt spell is cast
+-- @param spell table Executed spell definition
+-- @param caster table Wizard casting the spell
+function UnlockSystem.checkSpellUnlock(spell, caster)
+    if not spell or not caster then return end
+    if spell.affinity == "salt" and game and not game.unlockedCharacters.Silex then
+        game.unlockedCharacters.Silex = true
+        print("[UNLOCK] Silex has been unlocked!")
+        if caster.spellCastNotification then
+            caster.spellCastNotification.text = "Unlocked Silex!"
+            caster.spellCastNotification.timer = 2.0
+        else
+            caster.spellCastNotification = {
+                text = "Unlocked Silex!",
+                timer = 2.0,
+                x = caster.x,
+                y = caster.y + 70,
+                color = {1,1,0,1}
+            }
+        end
+    end
+end
+
+return UnlockSystem

--- a/wizard.lua
+++ b/wizard.lua
@@ -10,6 +10,7 @@ local Spells = SpellsModule.spells
 local ShieldSystem = require("systems.ShieldSystem")
 local WizardVisuals = require("systems.WizardVisuals")
 local TokenManager = require("systems.TokenManager")
+local UnlockSystem = require("systems.UnlockSystem")
 
 -- We'll use game.compiledSpells instead of a local compiled spells table
 
@@ -978,6 +979,9 @@ function Wizard:castSpell(spellSlot)
             print("Warning: Falling back to original spell - could not get compiled version of " .. spellToUse.id)
         end
     end
+
+    -- Check for character unlocks based on this spell
+    UnlockSystem.checkSpellUnlock(spellToUse, self)
     
     -- Get attack type for shield checking
     local attackType = spellToUse.attackType or Constants.AttackType.PROJECTILE


### PR DESCRIPTION
## Summary
- add unlock logic for Silex when any Salt spell is cast
- call unlock system from wizard cast logic
- explicitly list Silex in locked character table
- document unlocking in README

## Testing
- `git status --short`