### PR TITLE
Fix token scaling when snatched mid-animation

### DIFF
--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -41,6 +41,12 @@ Constants.TokenStatus = {
     POOLED = "POOLED"          -- Released to the object pool
 }
 
+-- Visual constants for tokens
+Constants.TokenVisuals = {
+    -- Scale applied when a token is placed in a spell slot
+    CHANNELED_SCALE = 1.0
+}
+
 -- Range positioning between wizards
 Constants.RangeState = {
     NEAR = "NEAR",

--- a/manapool.lua
+++ b/manapool.lua
@@ -50,13 +50,25 @@ local TokenMethods = {}
 -- Set the token's state with validation
 function TokenMethods:setState(newStatus)
     local oldStatus = self.status
-    
+
     -- Validate state transitions
     if self.status == Constants.TokenStatus.POOLED then
         print("[TOKEN LIFECYCLE] WARNING: Cannot transition from POOLED state!")
         return false
     end
-    
+
+    -- Finalize scale if leaving an animation state that modifies scale
+    if (oldStatus == Constants.TokenStatus.APPEARING or oldStatus == Constants.TokenStatus.ORBITING) and
+       (newStatus == Constants.TokenStatus.CHANNELED or
+        newStatus == Constants.TokenStatus.SHIELDING or
+        newStatus == Constants.TokenStatus.FREE) then
+        if self.targetScale then
+            self.scale = self.targetScale
+        else
+            self.scale = 0.85 + math.random() * 0.3
+        end
+    end
+
     -- Update the token's status
     self.status = newStatus
     
@@ -275,6 +287,13 @@ function TokenMethods:finalizeOrbit()
     -- Update position to make sure it's at the target
     self.x = self.targetOrbitX
     self.y = self.targetOrbitY
+
+    -- Ensure scale is finalized
+    if self.targetScale then
+        self.scale = self.targetScale
+    else
+        self.scale = 0.85 + math.random() * 0.3
+    end
     
     -- Clean up orbit animation properties
     self.startOrbitX = nil
@@ -398,8 +417,9 @@ function TokenMethods:finalizeAppear()
     self.targetRadiusY = valence.radiusY
     self.currentRadiusX = valence.radiusX
     self.currentRadiusY = valence.radiusY
-    
+
     -- Visual variance set during appearing animation
+    self.scale = self.targetScale
     self.zOrder = math.random()
     
     return true

--- a/systems/TokenManager.lua
+++ b/systems/TokenManager.lua
@@ -255,6 +255,13 @@ function TokenManager.positionTokensInSpellSlot(wizard, slotIndex, tokens)
         -- Store token's current position as the starting point for animation
         token.startX = token.x
         token.startY = token.y
+
+        -- Ensure the token appears at a consistent scale while channeled
+        if token.targetScale then
+            token.scale = token.targetScale
+        else
+            token.scale = Constants.TokenVisuals and Constants.TokenVisuals.CHANNELED_SCALE or 1.0
+        end
         
         -- Initialize animation parameters
         token.animTime = 0


### PR DESCRIPTION
## Summary
- define `Constants.TokenVisuals.CHANNELED_SCALE`
- force token scale when positioning them in spell slots
- ensure scale is finalized in `finalizeAppear` and `finalizeOrbit`
- finalize scale when leaving APPEARING or ORBITING via `setState`

## Testing
- `git status --short`
