### PR TITLE
Fix shield impact for blocked projectiles

### DIFF
--- a/vfx.lua
+++ b/vfx.lua
@@ -1219,7 +1219,11 @@ function VFX.update(dt)
                     effect.name or "unknown", effect.options.blockPoint))
                 
                 -- Create shield impact effect
-                if not effect.impactParticlesCreated and effect.type == "projectile" then
+                -- Trigger shield impact visuals for projectile-type effects
+                -- Accept both generic projectile templates (proj_base/bolt_base)
+                if not effect.impactParticlesCreated and
+                   (effect.type == "proj_base" or effect.type == "bolt_base" or
+                    effect.type == "projectile") then
                     effect.impactParticlesCreated = true
                     
                     -- Calculate impact position 


### PR DESCRIPTION
## Summary
- handle both `proj_base` and `bolt_base` projectile types when spawning shield impact VFX

## Testing
- `lua tools/test_vfx_events.lua` *(fails: `lua` command not found)*
- `./tools/check_magic_strings.lua` *(fails: Permission denied / missing Lua)*