### PR TITLE
Implement initial campaign state setup

### DIFF
--- a/characterData.lua
+++ b/characterData.lua
@@ -27,7 +27,8 @@ characterData.Ashgar = {
         Spells.eruption,
         Spells.combustMana,
         Spells.blazingAscent,
-    }
+    },
+    campaignOpponents = {"Selene", "Silex", "Borrak"}
 }
 
 characterData.Selene = {
@@ -51,7 +52,8 @@ characterData.Selene = {
         Spells.fullmoonbeam,
         Spells.lunardisjunction,
         Spells.lunarTides,
-    }
+    },
+    campaignOpponents = {"Ashgar", "Borrak", "Silex"}
 }
 
 characterData.Silex = {

--- a/core/Input.lua
+++ b/core/Input.lua
@@ -177,6 +177,9 @@ function Input.setupRoutes()
         elseif gameState.currentState == "CHARACTER_SELECT" then
             gameState.characterSelectBack(true)
             return true
+        elseif gameState.currentState == "CAMPAIGN_MENU" then
+            gameState.currentState = "MENU"
+            return true
         elseif gameState.currentState == "SETTINGS" then
             gameState.currentState = "MENU"
             return true
@@ -229,10 +232,9 @@ function Input.setupRoutes()
     end
     
     -- MENU CONTROLS
-    -- Campaign stub
     Input.Routes.ui["1"] = function()
         if gameState.currentState == "MENU" then
-            print("Campaign mode not implemented yet")
+            gameState.currentState = "CAMPAIGN_MENU"
             return true
         end
         return false

--- a/main.lua
+++ b/main.lua
@@ -51,7 +51,8 @@ game = {
     keywords = Keywords,
     spellCompiler = SpellCompiler,
     -- State management
-    currentState = "MENU", -- Start in the menu state (MENU, CHARACTER_SELECT, BATTLE, GAME_OVER, BATTLE_ATTRACT, GAME_OVER_ATTRACT)
+    currentState = "MENU", -- Start in the menu state (MENU, CHARACTER_SELECT, BATTLE, GAME_OVER, BATTLE_ATTRACT, GAME_OVER_ATTRACT, CAMPAIGN_MENU, CAMPAIGN_VICTORY, CAMPAIGN_DEFEAT)
+    campaignProgress = nil, -- Holds campaign run info when active
     -- Game mode
     useAI = false,         -- Whether to use AI for the second player
     -- Attract mode properties
@@ -1007,6 +1008,11 @@ function love.update(dt)
             game.vfx.update(dt)
         end
         return
+    elseif game.currentState == "CAMPAIGN_MENU" then
+        if game.vfx then
+            game.vfx.update(dt)
+        end
+        return
     elseif game.currentState == "CHARACTER_SELECT" then
         -- Simple animations for character select
         if game.vfx then
@@ -1240,6 +1246,10 @@ function love.draw()
         drawSettingsMenu()
     elseif game.currentState == "COMPENDIUM" then
         drawCompendium()
+    elseif game.currentState == "CAMPAIGN_MENU" then
+        -- Placeholder for campaign selection menu
+        love.graphics.setColor(1, 1, 1, 1)
+        love.graphics.print("Campaign Menu (WIP)", baseWidth/2 - 60, baseHeight/2)
     elseif game.currentState == "CHARACTER_SELECT" then
         drawCharacterSelect()
     elseif game.currentState == "BATTLE" or game.currentState == "BATTLE_ATTRACT" then


### PR DESCRIPTION
## Summary
- add `campaignOpponents` lists to Ashgar and Selene data
- recognize new campaign related states in `game` table
- hook up `1` key from main menu to open the campaign menu
- allow leaving the campaign menu with Escape
- placeholder update/draw logic for `CAMPAIGN_MENU`

## Testing
- `git status --short`