### PR TITLE
Add campaign failure screen

### DIFF
--- a/core/Input.lua
+++ b/core/Input.lua
@@ -181,6 +181,10 @@ function Input.setupRoutes()
             gameState.currentState = "MENU"
             gameState.campaignMenu = nil
             return true
+        elseif gameState.currentState == "CAMPAIGN_DEFEAT" then
+            gameState.currentState = "MENU"
+            gameState.campaignProgress = nil
+            return true
         elseif gameState.currentState == "SETTINGS" then
             gameState.currentState = "MENU"
             return true
@@ -422,14 +426,30 @@ function Input.setupRoutes()
         return false
     end
 
+    -- Campaign defeat options
+    Input.Routes.ui["space"] = function()
+        if gameState.currentState == "CAMPAIGN_DEFEAT" then
+            gameState.retryCampaignBattle()
+            return true
+        end
+        return false
+    end
+
+    Input.Routes.ui["r"] = function()
+        if gameState.currentState == "CAMPAIGN_DEFEAT" then
+            gameState.restartCampaign()
+            return true
+        end
+        return false
+    end
+
     -- Escape backs out of character select handled in global escape route
     
     -- GAME OVER STATE CONTROLS
-    -- Reset game on space bar press during game over
+    -- Advance from win screen on space bar press
     Input.Routes.gameOver["space"] = function()
         if gameState.currentState == "GAME_OVER" then
-            gameState.resetGame()
-            gameState.currentState = "MENU" -- Return to menu after game over
+            gameState.winScreenTimer = gameState.winScreenDuration
             return true
         end
         return false

--- a/main.lua
+++ b/main.lua
@@ -701,6 +701,39 @@ function exitAttractMode()
     print("Attract mode ended, returned to menu")
 end
 
+-- Handle successful completion of a campaign
+function handleCampaignVictory()
+    if not game.campaignProgress then return end
+    print(game.campaignProgress.characterName .. " campaign complete! Wins: " .. game.campaignProgress.wins)
+    game.currentState = "CAMPAIGN_VICTORY"
+end
+
+-- Handle failure of a campaign run
+function handleCampaignDefeat()
+    if not game.campaignProgress then return end
+    print(game.campaignProgress.characterName .. " campaign failed at opponent " .. game.campaignProgress.currentOpponentIndex)
+    resetGame()
+    game.currentState = "CAMPAIGN_DEFEAT"
+end
+
+-- Restart the entire campaign from the first opponent
+function restartCampaign()
+    if not game.campaignProgress then return end
+    game.campaignProgress.currentOpponentIndex = 1
+    game.campaignProgress.wins = 0
+    startCampaignBattle()
+end
+
+-- Retry the current campaign battle
+function retryCampaignBattle()
+    if not game.campaignProgress then return end
+    startCampaignBattle()
+end
+
+-- Expose campaign helpers
+game.restartCampaign = restartCampaign
+game.retryCampaignBattle = retryCampaignBattle
+
 -- Placeholder implementation for starting a campaign battle
 function startCampaignBattle()
     if not game.campaignProgress then
@@ -1082,6 +1115,11 @@ function love.update(dt)
             game.vfx.update(dt)
         end
         return
+    elseif game.currentState == "CAMPAIGN_DEFEAT" then
+        if game.vfx then
+            game.vfx.update(dt)
+        end
+        return
     elseif game.currentState == "CHARACTER_SELECT" then
         -- Simple animations for character select
         if game.vfx then
@@ -1173,11 +1211,20 @@ function love.update(dt)
         -- Update win screen timer
         game.winScreenTimer = game.winScreenTimer + dt
 
-        -- Auto-reset after duration
+        -- When timer expires, handle post-battle flow
         if game.winScreenTimer >= game.winScreenDuration then
-            -- Reset game and go back to menu
-            resetGame()
-            game.currentState = "MENU"
+            if game.campaignProgress then
+                if game.winner == 1 then
+                    game.campaignProgress.wins = game.campaignProgress.wins + 1
+                    game.campaignProgress.currentOpponentIndex = game.campaignProgress.currentOpponentIndex + 1
+                    startCampaignBattle()
+                else
+                    handleCampaignDefeat()
+                end
+            else
+                resetGame()
+                game.currentState = "MENU"
+            end
         end
 
         -- Still update VFX system for visual effects
@@ -1317,6 +1364,8 @@ function love.draw()
         drawCompendium()
     elseif game.currentState == "CAMPAIGN_MENU" then
         drawCampaignMenu()
+    elseif game.currentState == "CAMPAIGN_DEFEAT" then
+        drawCampaignDefeat()
     elseif game.currentState == "CHARACTER_SELECT" then
         drawCharacterSelect()
     elseif game.currentState == "BATTLE" or game.currentState == "BATTLE_ATTRACT" then
@@ -1960,6 +2009,33 @@ function drawCampaignMenu()
     local hint = "Choose your wizard"
     local hw = game.font:getWidth(hint)
     love.graphics.print(hint, screenWidth/2 - hw/2, startY - spacing)
+end
+
+-- Draw the campaign defeat screen
+function drawCampaignDefeat()
+    local screenWidth = baseWidth
+    local screenHeight = baseHeight
+
+    love.graphics.setColor(20/255, 20/255, 40/255, 1)
+    love.graphics.rectangle("fill", 0, 0, screenWidth, screenHeight)
+
+    local title = "Campaign Failed"
+    local titleScale = 2.5
+    local tw = game.font:getWidth(title) * titleScale
+    love.graphics.setColor(1, 0.6, 0.6, 1)
+    love.graphics.print(title, screenWidth/2 - tw/2, screenHeight*0.4, 0, titleScale, titleScale)
+
+    local options = {
+        "[R] Restart Campaign",
+        "[SPACE] Retry Battle",
+        "[ESC] Main Menu"
+    }
+    local startY = screenHeight * 0.6
+    for i, text in ipairs(options) do
+        local w = game.font:getWidth(text)
+        love.graphics.setColor(0.9, 0.9, 0.9, 0.9)
+        love.graphics.print(text, screenWidth/2 - w/2, startY + (i-1)*30)
+    end
 end
 
 -- Draw the character selection screen


### PR DESCRIPTION
## Summary
- show a simple Campaign Failed screen
- allow retrying or restarting the campaign
- update input routes for the new screen

## Testing
- `luac -p main.lua` *(fails: command not found)*
- `lua -e 'loadfile("main.lua")'` *(fails: command not found)*