### PR TITLE
Fix ward shield blocking of remote attacks

### DIFF
--- a/systems/ShieldSystem.lua
+++ b/systems/ShieldSystem.lua
@@ -59,7 +59,8 @@ function ShieldSystem.createShield(wizard, spellSlot, blockParams)
     
     -- Set which attack types this shield blocks
     slot.blocksAttackTypes = {}
-    local blockTypes = blockParams.blocks or {Constants.AttackType.PROJECTILE}
+    -- Support both `blocks` and `blocksAttackTypes` for compatibility
+    local blockTypes = blockParams.blocks or blockParams.blocksAttackTypes or {Constants.AttackType.PROJECTILE}
     for _, attackType in ipairs(blockTypes) do
         slot.blocksAttackTypes[attackType] = true
     end


### PR DESCRIPTION
## Summary
- ensure shield creation accepts `blocksAttackTypes` parameter
- Wards like Salt Circle now correctly block remote attacks

## Testing
- `lua5.3 tools/check_magic_strings.lua` *(fails: command not found)*