### PR TITLE
Implement dynamic spell cost mechanism

### DIFF
--- a/docs/spellcasting.md
+++ b/docs/spellcasting.md
@@ -26,9 +26,9 @@ This system is transitioning towards a pure event-based architecture, where spel
 *   **Purpose:** Defines the concrete spells available by combining keywords (`ingredients`) with specific parameters. Acts as a database of spell definitions.
 *   **Structure:** A large Lua table (`Spells`) where each key is a unique spell ID (e.g., `firebolt`). The value is a table adhering to a schema:
     *   **Basic Info:** `id`, `name`, `description`.
-    *   **Mechanics:** `attackType` (`projectile`, `remote`, `zone`, `utility`), `castTime`, `cost` (array of token types like `Constants.TokenType.FIRE`).
+    *   **Mechanics:** `attackType` (`projectile`, `remote`, `zone`, `utility`), `castTime`, `cost` (array of token types like `Constants.TokenType.FIRE`). If a `getCost` function is provided it will be used at runtime instead of the static table.
     *   **`keywords`:** **The core.** A table mapping keyword names (from `keywords.lua`) to parameter tables (e.g., `damage = { amount = 10 }`, `elevate = { duration = 5.0 }`). Parameters can be static values or functions.
-*   **Optional:** `vfx`, `sfx`, `getCastTime` (dynamic cast time function), `onBlock`/`onMiss`/`onSuccess` (legacy callbacks).
+*   **Optional:** `vfx`, `sfx`, `getCastTime` (dynamic cast time function), `getCost` (dynamic mana cost), `onBlock`/`onMiss`/`onSuccess` (legacy callbacks).
 *   **Validation:** Includes a `validateSpell` function called at load time to ensure schema adherence and add defaults, printing warnings for issues.
 
 ### 3. `spellCompiler.lua` - The Chef

--- a/docs/wizard.md
+++ b/docs/wizard.md
@@ -63,7 +63,7 @@ Each `Wizard` instance maintains a comprehensive set of state variables:
         *   Normal Spells: Applies damage (`target.health`), status effects (burn, stun), position changes (range, elevation), mana manipulation (lock, delay) based on `effect` table. Returns caster's tokens (`requestReturnAnimation`/`manaPool:returnToken`), resets caster's slot (`resetSpellSlot`).
 *   **`Wizard:handleShieldBlock(slotIndex, blockedSpell)`:** (Called on the target wizard). Consumes tokens from the specified shield slot based on `blockedSpell.shieldBreaker`, returns consumed tokens, and calls `resetSpellSlot` if the shield breaks (runs out of tokens).
 *   **`Wizard:resetSpellSlot(slotIndex)`:** Utility function to reset all properties of a spell slot to default/inactive state and clear its token list. Used after normal casts, cancellations, or shield breaks.
-*   **`Wizard:canPayManaCost(cost)`:** Checks if mana cost can be paid from `manaPool` *without* consuming tokens. Returns reservation details or `nil`.
+*   **`Wizard:canPayManaCost(costOrFn[, target])`:** Checks if a mana cost can be paid without consuming tokens. Accepts either a static cost table or a `getCost` function. Returns reservation details or `nil`.
 *   **`Wizard:freeAllSpells()`:** Cancels all active spells/shields, returns their tokens, and resets the corresponding slots.
 
 ### 3. Token Interaction

--- a/spellCompiler.lua
+++ b/spellCompiler.lua
@@ -68,6 +68,11 @@ function SpellCompiler.compileSpell(spellDef, keywordData)
     if spellDef.getCastTime and type(spellDef.getCastTime) == "function" then
         compiledSpell.getCastTime = spellDef.getCastTime
     end
+
+    -- >>> ADDED: Copy dynamic mana cost function if present
+    if spellDef.getCost and type(spellDef.getCost) == "function" then
+        compiledSpell.getCost = spellDef.getCost
+    end
     
     -- Process keywords if they exist
     if spellDef.keywords then


### PR DESCRIPTION
## Summary
- allow spells to define an optional `getCost` function
- support dynamic costs in `Wizard:queueSpell` and `Wizard:canPayManaCost`
- carry `getCost` through the spell compiler
- document the new behaviour in the spellcasting and wizard docs

## Testing
- `lua tools/check_magic_strings.lua` *(fails: `bash: lua: command not found`)*
- `lua tools/test_vfx_events.lua` *(fails: `bash: lua: command not found`)*
- `lua tools/test_particle_manager.lua` *(fails: `bash: lua: command not found`)*