### PR TITLE
Add dynamic cost spell examples

### DIFF
--- a/characterData.lua
+++ b/characterData.lua
@@ -27,6 +27,7 @@ characterData.Ashgar = {
         Spells.eruption,
         Spells.combustMana,
         Spells.blazingAscent,
+        Spells.desperationFire,
     },
     campaignOpponents = {"Selene", "Silex", "Borrak"}
 }
@@ -52,6 +53,7 @@ characterData.Selene = {
         Spells.fullmoonbeam,
         Spells.lunardisjunction,
         Spells.lunarTides,
+        Spells.moonDrain,
     },
     campaignOpponents = {"Ashgar", "Borrak", "Silex"}
 }

--- a/main.lua
+++ b/main.lua
@@ -176,6 +176,8 @@ game.unlockedSpells = {
     brinechain = true,
     maelstrom = true,
     wavecrash = true,
+    desperationfire = true,
+    moondrain = true,
 }
 
 -- Custom spellbooks configured by the player

--- a/spells/elements/fire.lua
+++ b/spells/elements/fire.lua
@@ -259,4 +259,30 @@ FireSpells.battleshield = {
     sfx = "fire_shield",
 }
 
+-- Desperation Fire - cost decreases as caster health drops
+FireSpells.desperationFire = {
+    id = "desperationfire",
+    name = "Desperation Fire",
+    affinity = Constants.TokenType.FIRE,
+    description = "A fiery attack whose Fire cost decreases as your health lowers.",
+    attackType = Constants.AttackType.PROJECTILE,
+    castTime = Constants.CastSpeed.NORMAL,
+    cost = { Constants.TokenType.FIRE, Constants.TokenType.FIRE, Constants.TokenType.FIRE },
+    keywords = {
+        damage = { amount = 15, type = Constants.DamageType.FIRE }
+    },
+    getCost = function(caster, target)
+        local fireCost = 3
+        if caster and caster.health < 75 then fireCost = 2 end
+        if caster and caster.health < 40 then fireCost = 1 end
+        if caster and caster.health < 20 then fireCost = 0 end
+
+        local finalCost = {}
+        for i = 1, fireCost do
+            table.insert(finalCost, Constants.TokenType.FIRE)
+        end
+        return finalCost
+    end,
+}
+
 return FireSpells

--- a/spells/elements/moon.lua
+++ b/spells/elements/moon.lua
@@ -390,4 +390,38 @@ MoonSpells.enhancedmirrorshield = {
     sfx = "crystal_ring",
 }
 
+-- Moon Drain - cost increases with opponent's STAR tokens
+MoonSpells.moonDrain = {
+    id = "moondrain",
+    name = "Moon Drain",
+    affinity = Constants.TokenType.MOON,
+    description = "Drains opponent. Costs more Moon tokens if opponent is channeling Star mana.",
+    attackType = Constants.AttackType.REMOTE,
+    castTime = Constants.CastSpeed.FAST,
+    cost = { Constants.TokenType.MOON },
+    keywords = {
+        damage = { amount = 8, type = Constants.DamageType.MOON }
+    },
+    getCost = function(caster, target)
+        local moonTokens = 1
+        if target then
+            for _, slot in ipairs(target.spellSlots) do
+                if slot.active and slot.tokens then
+                    for _, tokenData in ipairs(slot.tokens) do
+                        if tokenData.token.type == Constants.TokenType.STAR then
+                            moonTokens = moonTokens + 1
+                        end
+                    end
+                end
+            end
+        end
+
+        local finalCost = {}
+        for i = 1, math.min(moonTokens, 4) do
+            table.insert(finalCost, Constants.TokenType.MOON)
+        end
+        return finalCost
+    end,
+}
+
 return MoonSpells


### PR DESCRIPTION
## Summary
- implement `desperationFire` and `moonDrain` example spells demonstrating `getCost`
- expose them via Ashgar and Selene's spell lists
- unlock both spells for customization

## Testing
- `luac` not available; no tests run