### PR TITLE
Add docs for dynamic spell costs

### DIFF
--- a/DevelopmentGuidelines.md
+++ b/DevelopmentGuidelines.md
@@ -37,6 +37,7 @@ Add to game.unlockedSpells in main.lua if it's unlockable.
 Modifying or Adding Keywords (keywords.lua):
 Event Generation: The execute function must add events to the passed-in events table. It should not directly modify caster, target, or gameState.
 Parameters: Keyword parameters defined in spells.lua can be static values or functions (resolved by keywords.lua.resolve()).
+Dynamic Costs: Spells may include a `getCost(caster, target)` function which returns a token cost table at runtime. Use this for mechanics like health-scaled or target-dependent costs.
 Metadata: Keep the behavior table updated with descriptive flags, targetType, and category.
 VFX: Keywords generally should not trigger VFX directly. Instead, the events they generate (e.g., DAMAGE, SET_ELEVATION) will be picked up by EventRunner, which then uses VisualResolver for VFX. If a keyword has a unique, inherent visual distinct from its gameplay event (rare), it can generate a specific EFFECT event.
 Documentation: Update docs/keywords.lua (or ensure it's auto-generated) if adding or significantly changing a keyword.

--- a/docs/spellcasting.md
+++ b/docs/spellcasting.md
@@ -28,6 +28,24 @@ This system is transitioning towards a pure event-based architecture, where spel
     *   **Basic Info:** `id`, `name`, `description`.
     *   **Mechanics:** `attackType` (`projectile`, `remote`, `zone`, `utility`), `castTime`, `cost` (array of token types like `Constants.TokenType.FIRE`). If a `getCost` function is provided it will be used at runtime instead of the static table.
     *   **`keywords`:** **The core.** A table mapping keyword names (from `keywords.lua`) to parameter tables (e.g., `damage = { amount = 10 }`, `elevate = { duration = 5.0 }`). Parameters can be static values or functions.
+
+    The optional `getCost(caster, target)` function allows a spell's mana cost to change based on game state. It should return a table of token types just like the static `cost` field. `getCost` is evaluated each time the spell is queued or affordability is checked.
+
+    **Example:** A spell that gets cheaper as the caster's health drops might be implemented as:
+
+    ```lua
+    getCost = function(caster)
+        local fireCost = 3
+        if caster.health < 75 then fireCost = 2 end
+        if caster.health < 40 then fireCost = 1 end
+        if caster.health < 20 then fireCost = 0 end
+        local t = {}
+        for i = 1, fireCost do
+            t[i] = Constants.TokenType.FIRE
+        end
+        return t
+    end
+    ```
 *   **Optional:** `vfx`, `sfx`, `getCastTime` (dynamic cast time function), `getCost` (dynamic mana cost), `onBlock`/`onMiss`/`onSuccess` (legacy callbacks).
 *   **Validation:** Includes a `validateSpell` function called at load time to ensure schema adherence and add defaults, printing warnings for issues.
 

--- a/docs/wizard.md
+++ b/docs/wizard.md
@@ -49,6 +49,7 @@ Each `Wizard` instance maintains a comprehensive set of state variables:
 *   **`Wizard:queueSpell(spell)`:** Initiates spell casting.
     *   Finds an available `spellSlot`.
     *   Checks mana availability using `canPayManaCost`.
+        *   If the spell defines `getCost`, that function is called with `caster` and `target` to determine the token list.
     *   If affordable, acquires token references from `manaPool` via reservations.
     *   Sets token state to `CHANNELED`.
     *   Sets up animation parameters for tokens (Bezier curve towards wizard).
@@ -63,7 +64,7 @@ Each `Wizard` instance maintains a comprehensive set of state variables:
         *   Normal Spells: Applies damage (`target.health`), status effects (burn, stun), position changes (range, elevation), mana manipulation (lock, delay) based on `effect` table. Returns caster's tokens (`requestReturnAnimation`/`manaPool:returnToken`), resets caster's slot (`resetSpellSlot`).
 *   **`Wizard:handleShieldBlock(slotIndex, blockedSpell)`:** (Called on the target wizard). Consumes tokens from the specified shield slot based on `blockedSpell.shieldBreaker`, returns consumed tokens, and calls `resetSpellSlot` if the shield breaks (runs out of tokens).
 *   **`Wizard:resetSpellSlot(slotIndex)`:** Utility function to reset all properties of a spell slot to default/inactive state and clear its token list. Used after normal casts, cancellations, or shield breaks.
-*   **`Wizard:canPayManaCost(costOrFn[, target])`:** Checks if a mana cost can be paid without consuming tokens. Accepts either a static cost table or a `getCost` function. Returns reservation details or `nil`.
+*   **`Wizard:canPayManaCost(costOrFn[, target])`:** Checks if a mana cost can be paid without consuming tokens. `costOrFn` may be a static table or the `getCost` function from a spell definition. The function returns a reservation detail table or `nil` if the cost can't currently be met.
 *   **`Wizard:freeAllSpells()`:** Cancels all active spells/shields, returns their tokens, and resets the corresponding slots.
 
 ### 3. Token Interaction


### PR DESCRIPTION
## Summary
- document how `getCost` works in spell definitions
- mention dynamic cost handling in `queueSpell` and `canPayManaCost`
- add a note about dynamic costs to the development guidelines

## Testing
- `lua tools/check_magic_strings.lua` *(fails: command not found)*