### PR TITLE
Implement INPUT-1 player action enums and default bindings

### DIFF
--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -454,6 +454,39 @@ function Constants.isValidVFXType(value)
     return false
 end
 
+-- Abstract game actions for input mapping
+Constants.ControlAction = {
+    -- Player 1 actions
+    P1_SLOT1 = "p1_slot1",
+    P1_SLOT2 = "p1_slot2",
+    P1_SLOT3 = "p1_slot3",
+    P1_CAST  = "p1_cast",
+    P1_FREE  = "p1_free",
+    P1_BOOK  = "p1_book",
+
+    -- Player 2 actions
+    P2_SLOT1 = "p2_slot1",
+    P2_SLOT2 = "p2_slot2",
+    P2_SLOT3 = "p2_slot3",
+    P2_CAST  = "p2_cast",
+    P2_FREE  = "p2_free",
+    P2_BOOK  = "p2_book",
+
+    -- Menu navigation
+    MENU_UP    = "menu_up",
+    MENU_DOWN  = "menu_down",
+    MENU_LEFT  = "menu_left",
+    MENU_RIGHT = "menu_right",
+
+    -- Menu actions
+    MENU_CONFIRM      = "menu_confirm",
+    MENU_CANCEL_BACK  = "menu_cancel_back",
+
+    -- System actions
+    SYS_TOGGLE_DEBUG   = "sys_toggle_debug",
+    SYS_QUIT_MENU_BACK = "sys_quit_menu_back"
+}
+
 -- Motion styles for VFX particles
 Constants.MotionStyle = {
     RADIAL = "radial",     -- Particles expand outward in all directions (default)

--- a/core/Input.lua
+++ b/core/Input.lua
@@ -2,9 +2,11 @@
 -- Unified input routing system for Manastorm
 
 local Input = {}
+local Constants = require("core.Constants")
 
 -- Store a reference to the game state for routing
 local gameState = nil
+Input.controls = nil
 
 -- Set up input routes by category
 Input.Routes = {
@@ -33,6 +35,7 @@ Input.Routes = {
 -- Initialize with game state reference
 function Input.init(game)
     gameState = game
+    Input.controls = gameState.settings.get("controls")
     Input.setupRoutes()
 end
 
@@ -125,18 +128,25 @@ end
 -- Handle key release events
 function Input.handleKeyReleased(key, scancode)
     local controls = gameState.settings.get("controls")
-    -- Handle player 1 key releases
-    if key == controls.p1.slot1 or key == controls.p1.slot2 or key == controls.p1.slot3 then
-        local slotIndex = (key == controls.p1.slot1) and 1 or (key == controls.p1.slot2 and 2 or 3)
+    local kp1 = controls.keyboardP1 or (controls.p1 or {})
+    local kp2 = controls.keyboardP2 or (controls.p2 or {})
+
+    local p1s1 = kp1[Constants.ControlAction.P1_SLOT1] or kp1.slot1
+    local p1s2 = kp1[Constants.ControlAction.P1_SLOT2] or kp1.slot2
+    local p1s3 = kp1[Constants.ControlAction.P1_SLOT3] or kp1.slot3
+    if key == p1s1 or key == p1s2 or key == p1s3 then
+        local slotIndex = (key == p1s1) and 1 or (key == p1s2 and 2 or 3)
         if gameState and gameState.wizards and gameState.wizards[1] then
             gameState.wizards[1]:keySpell(slotIndex, false)
             return true
         end
     end
 
-    -- Handle player 2 key releases
-    if key == controls.p2.slot1 or key == controls.p2.slot2 or key == controls.p2.slot3 then
-        local slotIndex = (key == controls.p2.slot1) and 1 or (key == controls.p2.slot2 and 2 or 3)
+    local p2s1 = kp2[Constants.ControlAction.P2_SLOT1] or kp2.slot1
+    local p2s2 = kp2[Constants.ControlAction.P2_SLOT2] or kp2.slot2
+    local p2s3 = kp2[Constants.ControlAction.P2_SLOT3] or kp2.slot3
+    if key == p2s1 or key == p2s2 or key == p2s3 then
+        local slotIndex = (key == p2s1) and 1 or (key == p2s2 and 2 or 3)
         if gameState and gameState.wizards and gameState.wizards[2] then
             gameState.wizards[2]:keySpell(slotIndex, false)
             return true
@@ -465,8 +475,27 @@ function Input.setupRoutes()
     
     -- PLAYER 1 CONTROLS (Ashgar)
     local c = gameState.settings.get("controls")
-    local p1 = c.p1
-    local p2 = c.p2
+    Input.controls = c
+    local kp1 = c.keyboardP1 or (c.p1 or {})
+    local kp2 = c.keyboardP2 or (c.p2 or {})
+
+    local p1 = {
+        slot1 = kp1[Constants.ControlAction.P1_SLOT1] or kp1.slot1,
+        slot2 = kp1[Constants.ControlAction.P1_SLOT2] or kp1.slot2,
+        slot3 = kp1[Constants.ControlAction.P1_SLOT3] or kp1.slot3,
+        cast  = kp1[Constants.ControlAction.P1_CAST]  or kp1.cast,
+        free  = kp1[Constants.ControlAction.P1_FREE]  or kp1.free,
+        book  = kp1[Constants.ControlAction.P1_BOOK]  or kp1.book
+    }
+
+    local p2 = {
+        slot1 = kp2[Constants.ControlAction.P2_SLOT1] or kp2.slot1,
+        slot2 = kp2[Constants.ControlAction.P2_SLOT2] or kp2.slot2,
+        slot3 = kp2[Constants.ControlAction.P2_SLOT3] or kp2.slot3,
+        cast  = kp2[Constants.ControlAction.P2_CAST]  or kp2.cast,
+        free  = kp2[Constants.ControlAction.P2_FREE]  or kp2.free,
+        book  = kp2[Constants.ControlAction.P2_BOOK]  or kp2.book
+    }
 
     -- Key spell slots
     Input.Routes.p1[p1.slot1] = function()

--- a/core/Settings.lua
+++ b/core/Settings.lua
@@ -1,12 +1,51 @@
 local Settings = {}
+local Constants = require("core.Constants")
 
 -- Default configuration
 local defaults = {
     dummyFlag = false,
     gameSpeed = "FAST",
     controls = {
-        p1 = { slot1 = "q", slot2 = "w", slot3 = "e", cast = "f", free = "g", book = "b" },
-        p2 = { slot1 = "i", slot2 = "o", slot3 = "p", cast = "j", free = "h", book = "m" }
+        keyboardP1 = {
+            [Constants.ControlAction.P1_SLOT1] = "q",
+            [Constants.ControlAction.P1_SLOT2] = "w",
+            [Constants.ControlAction.P1_SLOT3] = "e",
+            [Constants.ControlAction.P1_CAST]  = "f",
+            [Constants.ControlAction.P1_FREE]  = "g",
+            [Constants.ControlAction.P1_BOOK]  = "b",
+            [Constants.ControlAction.MENU_UP]    = "up",
+            [Constants.ControlAction.MENU_DOWN]  = "down",
+            [Constants.ControlAction.MENU_LEFT]  = "left",
+            [Constants.ControlAction.MENU_RIGHT] = "right",
+            [Constants.ControlAction.MENU_CONFIRM]     = "return",
+            [Constants.ControlAction.MENU_CANCEL_BACK] = "escape"
+        },
+        keyboardP2 = {
+            [Constants.ControlAction.P2_SLOT1] = "i",
+            [Constants.ControlAction.P2_SLOT2] = "o",
+            [Constants.ControlAction.P2_SLOT3] = "p",
+            [Constants.ControlAction.P2_CAST]  = "j",
+            [Constants.ControlAction.P2_FREE]  = "h",
+            [Constants.ControlAction.P2_BOOK]  = "m"
+        },
+        gamepadP1 = {
+            [Constants.ControlAction.P1_SLOT1] = "dpdown",
+            [Constants.ControlAction.P1_SLOT2] = "dpleft",
+            [Constants.ControlAction.P1_SLOT3] = "dpright",
+            [Constants.ControlAction.P1_CAST]  = "a",
+            [Constants.ControlAction.P1_FREE]  = "y",
+            [Constants.ControlAction.P1_BOOK]  = "b",
+            [Constants.ControlAction.MENU_UP]    = "dpup",
+            [Constants.ControlAction.MENU_DOWN]  = "dpdown",
+            [Constants.ControlAction.MENU_LEFT]  = "dpleft",
+            [Constants.ControlAction.MENU_RIGHT] = "dpright",
+            [Constants.ControlAction.MENU_CONFIRM]     = "a",
+            [Constants.ControlAction.MENU_CANCEL_BACK] = "b"
+        },
+        gamepadP2 = {
+            [Constants.ControlAction.P2_SLOT1] = "dpdown",
+            -- Placeholder for P2 controller mappings
+        }
     }
 }
 
@@ -42,6 +81,20 @@ local function serialize(tbl, indent)
     return table.concat(parts)
 end
 
+local function mergeDefaults(target, default)
+    for k, v in pairs(default) do
+        if type(v) == "table" then
+            if type(target[k]) ~= "table" then
+                target[k] = deepcopy(v)
+            else
+                mergeDefaults(target[k], v)
+            end
+        elseif target[k] == nil then
+            target[k] = v
+        end
+    end
+end
+
 Settings.data = nil
 
 function Settings.load()
@@ -54,6 +107,8 @@ function Settings.load()
             if type(Settings.data.gameSpeed) ~= "string" then
                 Settings.data.gameSpeed = "FAST"
             end
+            -- Merge new defaults for missing values
+            mergeDefaults(Settings.data, defaults)
             return
         end
     end


### PR DESCRIPTION
## Summary
- enumerate `Constants.ControlAction`
- define new default control mappings in `Settings`
- load control mappings in `Input.init`
- adapt `Input` to work with new settings structure

## Testing
- `luajit` not available, so `tools/check_magic_strings.lua` couldn't be run