### PR TITLE
Document input system actions and defaults

### DIFF
--- a/CrashCourse.md
+++ b/CrashCourse.md
@@ -54,7 +54,9 @@ Core Utilities (core/):
 Constants.lua: Centralized string constants. Crucial for avoiding magic strings.
 AssetCache.lua: Prevents duplicate loading of images and sounds.
 Pool.lua: Generic object pooling system.
-Input.lua: Unified input routing.
+Input.lua: Unified input routing. Uses an action-based scheme defined in
+  `Constants.ControlAction`. Keyboard and gamepad bindings are loaded from
+  Settings.lua and can be changed at runtime.
 Settings.lua: Handles persistent game settings.
 assetPreloader.lua: Manages preloading of assets.
 3. Key Interactions & Data Flow

--- a/DevelopmentGuidelines.md
+++ b/DevelopmentGuidelines.md
@@ -53,6 +53,10 @@ Create new personality files that implement the interface defined in ai/Personal
 Personality modules are responsible for spell selection logic for a specific character.
 Keep the core OpponentAI.lua generic; character-specific logic belongs in personality modules.
 AI actions should use wizard:queueSpell(), not simulate input.
+Input Handling:
+  The game uses an action-based input layer. All actions are defined in
+  `Constants.ControlAction`. Default bindings for keyboard and gamepad live in
+  `core/Settings.lua` and can be rebound at runtime through the Settings menu.
 UI (ui.lua, main.lua draw functions):
 Strive for diegetic UI where possible (information integrated into the game world).
 Keep UI drawing logic separate from game state update logic.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,34 @@ Manastorm is a real-time strategic battler where two spellcasters clash in arcan
 
 ## Controls
 
-### Player 1 (Ashgar)
-- Q, W, E: Queue spells in spell slots 1, 2, and 3
+Manastorm uses an **action-based** input layer. Each action is defined in
+`Constants.ControlAction` and can be bound independently for keyboard or
+gamepad via the Settings menu. The mappings below reflect the defaults shipped
+with the game.
 
-### Player 2 (Selene)
-- I, O, P: Queue spells in spell slots 1, 2, and 3
+### Default Keyboard Mapping
+
+**Player 1**
+
+- Q / W / E: Spell slots 1–3
+- F: Cast (also acts as menu confirm)
+- G: Free spells (also acts as menu cancel)
+- B: Toggle spellbook
+- Arrow Keys: Menu navigation
+
+**Player 2**
+
+- I / O / P: Spell slots 1–3
+- J: Cast
+- H: Free spells
+- M: Toggle spellbook
+
+### Default Gamepad Mapping
+
+Gamepad controls mirror the keyboard actions. Use the D-pad for spell slots and
+menu navigation. The **A** button casts or confirms, **Y** frees or cancels, and
+**B** toggles the spellbook. When a second gamepad is connected these mappings
+apply to Player 2 as well.
 
 ### General
 - ESC: Quit the game

--- a/core/Input.lua
+++ b/core/Input.lua
@@ -991,8 +991,33 @@ function Input.update(dt)
     end
 end
 
--- Document all currently used keys
+-- Document all currently used keys and default bindings
+-- `actions` mirrors the defaults defined in core/Settings.lua so that
+-- documentation and debug overlays can display current mappings.
 Input.reservedKeys = {
+    actions = {
+        [Constants.ControlAction.P1_SLOT1] = {keyboardP1 = "q", gamepadP1 = "dpdown"},
+        [Constants.ControlAction.P1_SLOT2] = {keyboardP1 = "w", gamepadP1 = "dpleft"},
+        [Constants.ControlAction.P1_SLOT3] = {keyboardP1 = "e", gamepadP1 = "dpright"},
+        [Constants.ControlAction.P1_CAST]  = {keyboardP1 = "f", gamepadP1 = "a"},
+        [Constants.ControlAction.P1_FREE]  = {keyboardP1 = "g", gamepadP1 = "y"},
+        [Constants.ControlAction.P1_BOOK]  = {keyboardP1 = "b", gamepadP1 = "b"},
+
+        [Constants.ControlAction.P2_SLOT1] = {keyboardP2 = "i", gamepadP2 = "dpdown"},
+        [Constants.ControlAction.P2_SLOT2] = {keyboardP2 = "o", gamepadP2 = "dpleft"},
+        [Constants.ControlAction.P2_SLOT3] = {keyboardP2 = "p", gamepadP2 = "dpright"},
+        [Constants.ControlAction.P2_CAST]  = {keyboardP2 = "j", gamepadP2 = "a"},
+        [Constants.ControlAction.P2_FREE]  = {keyboardP2 = "h", gamepadP2 = "y"},
+        [Constants.ControlAction.P2_BOOK]  = {keyboardP2 = "m", gamepadP2 = "b"},
+
+        [Constants.ControlAction.MENU_UP]    = {keyboardP1 = "up",    keyboardP2 = "up",    gamepadP1 = "dpup",    gamepadP2 = "dpup"},
+        [Constants.ControlAction.MENU_DOWN]  = {keyboardP1 = "down",  keyboardP2 = "down",  gamepadP1 = "dpdown",  gamepadP2 = "dpdown"},
+        [Constants.ControlAction.MENU_LEFT]  = {keyboardP1 = "left",  keyboardP2 = "left",  gamepadP1 = "dpleft",  gamepadP2 = "dpleft"},
+        [Constants.ControlAction.MENU_RIGHT] = {keyboardP1 = "right", keyboardP2 = "right", gamepadP1 = "dpright", gamepadP2 = "dpright"},
+        [Constants.ControlAction.MENU_CONFIRM]     = {keyboardP1 = "return", keyboardP2 = "return", gamepadP1 = "a", gamepadP2 = "a"},
+        [Constants.ControlAction.MENU_CANCEL_BACK] = {keyboardP1 = "escape", keyboardP2 = "escape", gamepadP1 = "b", gamepadP2 = "b"}
+    },
+
     system = {
         "Alt+1", "Alt+2", "Alt+3", "Alt+f", -- Window scaling
         "Ctrl+R", -- Asset reload


### PR DESCRIPTION
## Summary
- list action defaults in `Input.reservedKeys`
- update README controls to describe the action-based system
- clarify input layer in CrashCourse and DevelopmentGuidelines

## Testing
- `lua tools/check_magic_strings.lua` *(fails: `lua` not found)*