### PR TITLE
Fix lingering flash from beam VFX

### DIFF
--- a/vfx.lua
+++ b/vfx.lua
@@ -1477,10 +1477,19 @@ function VFX.draw()
         local effectType = effect.type
         local drawer = VFX.drawers[effectType]
         if drawer then
+            -- Preserve current graphics state so individual effect draw calls
+            -- cannot permanently modify color or blend mode
+            local prevR, prevG, prevB, prevA = love.graphics.getColor()
+            local prevBlendSrc, prevBlendDst = love.graphics.getBlendMode()
+
             -- Add safety pcall to prevent crashes
             local success, err = pcall(function()
                 drawer(effect)
             end)
+
+            -- Restore graphics state
+            love.graphics.setColor(prevR, prevG, prevB, prevA)
+            love.graphics.setBlendMode(prevBlendSrc, prevBlendDst)
 
             if not success then
                 print(string.format("[VFX] Error drawing effect type '%s': %s", tostring(effectType), tostring(err)))

--- a/vfx/effects/beam.lua
+++ b/vfx/effects/beam.lua
@@ -597,9 +597,10 @@ local function drawBeam(effect)
         love.graphics.setBlendMode(prevMode[1], prevMode[2])
     end
 
-    -- Restore the previous line width and blend mode to avoid affecting other draw calls
+    -- Restore the previous line width, blend mode, and color to avoid affecting other draw calls
     love.graphics.setLineWidth(prevLineWidth)
     love.graphics.setBlendMode(prevBlendMode[1], prevBlendMode[2])
+    love.graphics.setColor(1, 1, 1, 1)
 end
 
 -- Initialize function for beam effects


### PR DESCRIPTION
## Summary
- restore graphics state after every VFX draw call
- reset color after drawing beam effects

## Testing
- `lua` not available; no tests run