### PR TITLE
Add Zap visual template

### DIFF
--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -362,6 +362,7 @@ Constants.VFXType = {
     -- Base template effects (used by VisualResolver)
     PROJ_BASE = "proj_base",       -- Base projectile effect
     BOLT_BASE = "bolt_base",       -- Base bolt effect
+    ZAP_BASE = "zap_base",        -- Base zap lightning effect
     ORB_BASE = "orb_base",         -- Base orb effect (lobbed arc projectile)
     BEAM_BASE = "beam_base",       -- Base beam effect
     REMOTE_BASE = "remote_base",   -- Base remote effect (explosion/flash)

--- a/docs/visualShape.md
+++ b/docs/visualShape.md
@@ -39,7 +39,8 @@ Without the `visualShape` property, this spell would use the `remote_base` templ
 The `visualShape` property supports the following values:
 
 - `"beam"` - A sustained beam effect (uses `beam_base` template)
-- `"bolt"` or `"orb"` or `"zap"` - Projectile effects (use `proj_base` template)
+- `"bolt"` or `"orb"` - Projectile effects (use `proj_base` template)
+- `"zap"` - Lightning bolt effect (uses `zap_base` template)
 - `"blast"` or `"groundBurst"` - Area effects (use `zone_base` template)
 - `"warp"`, `"surge"`, or `"affectManaPool"` - Utility effects (use `util_base` template)
 - `"wings"` or `"mirror"` - Shield/barrier effects (use `shield_overlay` template)

--- a/systems/VisualResolver.lua
+++ b/systems/VisualResolver.lua
@@ -11,7 +11,7 @@ local TEMPLATE_BY_SHAPE = {
     
     -- Projectile-like effects
     ["beam"] = Constants.VFXType.BEAM_BASE,
-    ["zap"] = Constants.VFXType.PROJ_BASE,
+    ["zap"] = Constants.VFXType.ZAP_BASE,
     ["bolt"] = Constants.VFXType.BOLT_BASE,
     ["orb"] = Constants.VFXType.ORB_BASE,
     

--- a/vfx.lua
+++ b/vfx.lua
@@ -118,6 +118,13 @@ function VFX.init()
             "assets/sprites/warp/warp3.png"
         },
 
+        -- Zap effects
+        zapFrames = {
+            "assets/sprites/zap/zap1.png",
+            "assets/sprites/zap/zap2.png",
+            "assets/sprites/zap/zap3.png"
+        },
+
         -- Pixel primitive
         pixel = "assets/sprites/1px.png",
 
@@ -200,6 +207,19 @@ function VFX.init()
             print("[VFX] Warning: Failed to preload warp frame asset: " .. warpPath)
         end
     end
+
+    -- Preload zap frames for the zap effects
+    print("[VFX] Preloading zap frame assets")
+    VFX.assets.zapFrames = {}
+    for i, zapPath in ipairs(VFX.assetPaths.zapFrames) do
+        print("[VFX] Preloading zap frame " .. i)
+        local zapImg = AssetCache.getImage(zapPath)
+        if zapImg then
+            table.insert(VFX.assets.zapFrames, zapImg)
+        else
+            print("[VFX] Warning: Failed to preload zap frame asset: " .. zapPath)
+        end
+    end
     
     -- Effect definitions keyed by effect name
     VFX.effects = {
@@ -249,6 +269,16 @@ function VFX.init()
             useSourcePosition = true,     -- Track source (caster) position
             useTargetPosition = true,     -- Track target position
             criticalAssets = {"boltFrames"} -- Mark bolt frames as critical assets to preload
+        },
+
+        zap_base = {
+            type = "zap_base",
+            duration = 0.6,
+            color = Constants.Color.GRAY,
+            segmentLength = 20,
+            useSourcePosition = true,
+            useTargetPosition = true,
+            criticalAssets = {"zapFrames"}
         },
 
         orb_base = {
@@ -1637,12 +1667,14 @@ local ConjureEffect = require("vfx.effects.conjure")
 local SurgeEffect = require("vfx.effects.surge")
 local RemoteEffect = require("vfx.effects.remote")
 local MeteorEffect = require("vfx.effects.meteor")
+local ZapEffect = require("vfx.effects.zap")
 
 -- Initialize the updaters table with update functions
 -- Map each template name/type to the appropriate handler
 VFX.updaters["proj_base"] = ProjectileEffect.update  -- Generic projectile template
 VFX.updaters["bolt_base"] = ProjectileEffect.update  -- Bolt uses projectile logic
 VFX.updaters["orb_base"] = ProjectileEffect.update   -- Orb uses projectile logic
+VFX.updaters["zap_base"] = ZapEffect.update        -- Zap lightning effect
 VFX.updaters["impact_base"] = ImpactEffect.update    -- Impact effect template
 VFX.updaters["beam_base"] = BeamEffect.update        -- Beam effect template
 VFX.updaters["blast_base"] = ConeEffect.update       -- Blast uses cone logic
@@ -1671,6 +1703,7 @@ VFX.updaters[Constants.AttackType.PROJECTILE] = ProjectileEffect.update
 VFX.drawers["proj_base"] = ProjectileEffect.draw    -- Generic projectile template
 VFX.drawers["bolt_base"] = ProjectileEffect.draw    -- Bolt uses projectile logic
 VFX.drawers["orb_base"] = ProjectileEffect.draw     -- Orb uses projectile logic
+VFX.drawers["zap_base"] = ZapEffect.draw          -- Zap lightning effect
 VFX.drawers["impact_base"] = ImpactEffect.draw      -- Impact effect template
 VFX.drawers["beam_base"] = BeamEffect.draw          -- Beam effect template
 VFX.drawers["blast_base"] = ConeEffect.draw         -- Blast uses cone logic

--- a/vfx/effects/zap.lua
+++ b/vfx/effects/zap.lua
@@ -1,0 +1,75 @@
+-- zap.lua
+-- Simple lightning zap effect drawing tiled sprites between source and target
+
+local VFX
+
+local function getAssetInternal(assetId)
+    if not VFX then
+        VFX = require("vfx")
+    end
+    return VFX.getAsset(assetId)
+end
+
+local function initializeZap(effect)
+    effect.timer = 0
+end
+
+local function updateZap(effect, dt)
+    -- ensure defaults
+    effect.useSourcePosition = (effect.useSourcePosition ~= false)
+    effect.useTargetPosition = (effect.useTargetPosition ~= false)
+    effect.followSourceEntity = (effect.followSourceEntity ~= false)
+    effect.followTargetEntity = (effect.followTargetEntity ~= false)
+    effect.color = effect.color or {1,1,1}
+    effect.segmentLength = effect.segmentLength or 20
+
+    if effect.useSourcePosition and effect.followSourceEntity and effect.sourceEntity then
+        if effect.sourceEntity.x and effect.sourceEntity.y then
+            effect.sourceX = effect.sourceEntity.x
+            effect.sourceY = effect.sourceEntity.y
+        end
+    end
+    if effect.useTargetPosition and effect.followTargetEntity and effect.targetEntity then
+        if effect.targetEntity.x and effect.targetEntity.y then
+            effect.targetX = effect.targetEntity.x
+            effect.targetY = effect.targetEntity.y
+        end
+    end
+
+    local dx = (effect.targetX or 0) - (effect.sourceX or 0)
+    local dy = (effect.targetY or 0) - (effect.sourceY or 0)
+    effect.angle = math.atan2(dy, dx)
+    effect.length = math.sqrt(dx*dx + dy*dy)
+    effect.headX = (effect.sourceX or 0) + dx * (effect.progress or 0)
+    effect.headY = (effect.sourceY or 0) + dy * (effect.progress or 0)
+end
+
+local function drawZap(effect)
+    local frames = getAssetInternal("zapFrames")
+    if not frames or #frames < 3 then return end
+    local seg1, seg2, terminus = frames[1], frames[2], frames[3]
+
+    love.graphics.setColor(effect.color[1], effect.color[2], effect.color[3], 1)
+
+    local segLen = effect.segmentLength or seg1:getWidth()
+    local drawn = 0
+    local maxLen = math.min(effect.length, effect.length * (effect.progress or 0))
+
+    while drawn + segLen < maxLen do
+        local img = (math.floor(drawn/segLen) % 2 == 0) and seg1 or seg2
+        local x = effect.sourceX + math.cos(effect.angle) * drawn
+        local y = effect.sourceY + math.sin(effect.angle) * drawn
+        love.graphics.draw(img, x, y, effect.angle, 1, 1, 0, img:getHeight()/2)
+        drawn = drawn + segLen
+    end
+
+    -- draw terminus at head
+    love.graphics.draw(terminus, effect.headX, effect.headY, effect.angle, 1, 1,
+        terminus:getWidth()/2, terminus:getHeight()/2)
+end
+
+return {
+    initialize = initializeZap,
+    update = updateZap,
+    draw = drawZap
+}


### PR DESCRIPTION
## Summary
- add `ZAP_BASE` to available VFX constants
- map `zap` visualShape to zap_base in VisualResolver
- preload zap sprites and define new `zap_base` effect
- implement zap effect for lightning visuals
- document new visualShape mapping

## Testing
- `lua tools/test_vfx_events.lua` *(fails: `lua` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8f2587f0832b9f50e6fa9c0c05a8