### PR TITLE
Fix Zap visual fallback bug

### DIFF
--- a/vfx.lua
+++ b/vfx.lua
@@ -1107,9 +1107,15 @@ function VFX.createEffect(effectName, sourceX, sourceY, targetX, targetY, option
     if opts.scale then
         -- Apply scale factor to particle counts, sizes, radii, etc.
         local scaleFactor = opts.scale
-        effect.particleCount = math.floor(effect.particleCount * scaleFactor)
-        effect.startScale = effect.startScale * scaleFactor
-        effect.endScale = effect.endScale * scaleFactor
+        if effect.particleCount then
+            effect.particleCount = math.floor(effect.particleCount * scaleFactor)
+        end
+        if effect.startScale then
+            effect.startScale = effect.startScale * scaleFactor
+        end
+        if effect.endScale then
+            effect.endScale = effect.endScale * scaleFactor
+        end
         if effect.radius then effect.radius = effect.radius * scaleFactor end
         if effect.beamWidth then effect.beamWidth = effect.beamWidth * scaleFactor end
         if effect.height then effect.height = effect.height * scaleFactor end

--- a/vfx/initializeParticles.lua
+++ b/vfx/initializeParticles.lua
@@ -18,6 +18,7 @@ local function initializeParticles(effect)
         ["proj_base"] = "projectile",
         ["bolt_base"] = "projectile",
         ["orb_base"] = "projectile",
+        ["zap_base"] = "zap",
         ["impact_base"] = "impact",
         ["beam_base"] = "beam",
         ["blast_base"] = "cone",


### PR DESCRIPTION
## Summary
- avoid math on nil fields when scaling VFX
- hook up zap_base in particle initializer

## Testing
- `lua tools/check_magic_strings.lua` *(fails: `bash: lua: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d947e72cc832b9a5c67970ceb66dd