### PR TITLE
Add Wave VFX base template

### DIFF
--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -372,6 +372,7 @@ Constants.VFXType = {
     BLAST_BASE = "blast_base",     -- Base conical blast effect
     UTIL_BASE = "util_base",       -- Base utility effect
     SURGE_BASE = "surge_base",      -- Base surge fountain effect
+    WAVE_BASE = "wave_base",       -- Base flowing wave effect
     CONJURE_BASE = "conjure_base", -- Base token conjuration effect
     IMPACT_BASE = "impact_base",   -- Base impact effect
     

--- a/systems/VisualResolver.lua
+++ b/systems/VisualResolver.lua
@@ -14,6 +14,7 @@ local TEMPLATE_BY_SHAPE = {
     ["zap"] = Constants.VFXType.ZAP_BASE,
     ["bolt"] = Constants.VFXType.BOLT_BASE,
     ["orb"] = Constants.VFXType.ORB_BASE,
+    ["wave"] = Constants.VFXType.WAVE_BASE,
     
     -- Area/zone effects
     ["blast"] = Constants.VFXType.BLAST_BASE,  -- Updated to new BLAST_BASE template

--- a/vfx.lua
+++ b/vfx.lua
@@ -431,6 +431,25 @@ function VFX.init()
             criticalAssets = {"pixel", "twinkle1", "twinkle2"} -- Required assets
         },
 
+        wave_base = {
+            type = "wave_base",          -- Template name as type
+            duration = 1.2,
+            particleCount = 120,
+            startScale = 0.5,
+            endScale = 0.9,
+            color = Constants.Color.GRAY,  -- Default color, will be overridden
+            trailLength = 20,
+            impactSize = 1.4,
+            coreDensity = 0.4,
+            trailDensity = 0.6,
+            turbulence = 0.75,
+            arcHeight = 40,
+            particleLifespan = 0.7,
+            leadingIntensity = 1.6,
+            useSprites = false,
+            criticalAssets = {"pixel", "twinkle1", "twinkle2"}
+        },
+
         conjure_base = {
             type = "conjure_base",        -- Template name as type
             duration = 0.8,
@@ -1687,6 +1706,7 @@ VFX.updaters["blast_base"] = ConeEffect.update       -- Blast uses cone logic
 VFX.updaters["zone_base"] = AuraEffect.update        -- Zone uses aura logic
 VFX.updaters["util_base"] = AuraEffect.update        -- Utility uses aura logic
 VFX.updaters["surge_base"] = SurgeEffect.update      -- Surge fountain template
+VFX.updaters["wave_base"] = ProjectileEffect.update  -- Flowing wave uses projectile logic
 VFX.updaters["conjure_base"] = ConjureEffect.update  -- Conjuration template
 VFX.updaters["remote_base"] = RemoteEffect.update    -- Remote effect template
 VFX.updaters["warp_base"] = RemoteEffect.update      -- Warp uses remote logic
@@ -1716,6 +1736,7 @@ VFX.drawers["blast_base"] = ConeEffect.draw         -- Blast uses cone logic
 VFX.drawers["zone_base"] = AuraEffect.draw          -- Zone uses aura logic
 VFX.drawers["util_base"] = AuraEffect.draw          -- Utility uses aura logic
 VFX.drawers["surge_base"] = SurgeEffect.draw        -- Surge fountain template
+VFX.drawers["wave_base"] = ProjectileEffect.draw    -- Flowing wave uses projectile logic
 VFX.drawers["conjure_base"] = ConjureEffect.draw    -- Conjuration template
 VFX.drawers["remote_base"] = RemoteEffect.draw      -- Remote effect template
 VFX.drawers["warp_base"] = RemoteEffect.draw        -- Warp uses remote logic

--- a/vfx/initializeParticles.lua
+++ b/vfx/initializeParticles.lua
@@ -25,6 +25,7 @@ local function initializeParticles(effect)
         ["zone_base"] = "aura",
         ["util_base"] = "aura",
         ["surge_base"] = "surge",
+        ["wave_base"] = "projectile",
         ["conjure_base"] = "conjure",
         ["remote_base"] = "remote",
         ["warp_base"] = "remote",


### PR DESCRIPTION
## Summary
- define `WAVE_BASE` constant
- map new `wave` visual shape to the `wave_base` template in the resolver
- implement `wave_base` effect using projectile logic and primitive sprites
- route initialization for the new template in `initializeParticles`

## Testing
- `VisualResolver.test()` *(fails: lua not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d9702cb1c832b95930900a0950fb4